### PR TITLE
Add styling for new link flair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Sass-created files
 .sass-cache
-*.map
 
 main.css

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ build:
 
 clean:
 	rm main.css
+	rm main.css.map
 
 .PHONY: all build clean

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 all: build
 
 build:
-	sass --style compressed main.scss main.css
+	sass --style compressed --sourcemap=none main.scss main.css
 
 clean:
 	rm main.css
-	rm main.css.map
 
 .PHONY: all build clean

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,7 @@ build:
 clean:
 	rm main.css
 
-.PHONY: all build clean
+watch:
+	sass --style compressed --sourcemap=none --watch main.scss:main.css
+
+.PHONY: all build clean watch

--- a/custom.scss
+++ b/custom.scss
@@ -2188,108 +2188,6 @@ side .md a[href*="#free_rotation2"] {
     background-position: 40px -2240px
 }
 
-.linkflair-modpost .linkflairlabel {
-    background-color: #add5ab;
-    font-size: 11px;
-    font-weight: 700;
-    color: #000;
-    border-color: #000;
-    border-width: 1px
-}
-
-.linkflair-blizzard .linkflairlabel,
-.linkflair-weekly .linkflairlabel {
-    background-color: #000;
-    font-size: 11px;
-    font-weight: 700;
-    border-color: #000
-}
-
-.linkflair-weekly .linkflairlabel {
-    color: #FFF;
-    border-width: 1px
-}
-
-.linkflair-blizzard .linkflairlabel {
-    color: #00b4ff;
-    border-width: 0;
-    padding: 3px
-}
-
-.linkflair-Default .linkflairlabel,
-.linkflair-awesome .linkflairlabel,
-.linkflair-blizzcon .linkflairlabel,
-.linkflair-bug .linkflairlabel,
-.linkflair-esports .linkflairlabel,
-.linkflair-gameplay .linkflairlabel,
-.linkflair-rage .linkflairlabel,
-.linkflair-show .linkflairlabel,
-.linkflair-vod .linkflairlabel {
-    font-size: 11px;
-    font-weight: 700
-}
-
-.linkflair-gameplay .linkflairlabel {
-    background-color: #900;
-    color: #FFF
-}
-
-.linkflair-vod .linkflairlabel {
-    background-color: #36F;
-    color: #FFF
-}
-
-.linkflair-bug .linkflairlabel {
-    background-color: #E68A00;
-    color: #FFF
-}
-
-.linkflair-show .linkflairlabel {
-    background-color: #060;
-    color: #FFF
-}
-
-.linkflair-esports .linkflairlabel {
-    background-color: #330081;
-    color: #FFF
-}
-
-.linkflair-awesome .linkflairlabel {
-    background-color: #FFF;
-    color: #000
-}
-
-.linkflair-Default .linkflairlabel {
-    background-color: #AAA;
-    color: #000
-}
-
-.linkflair-blizzcon .linkflairlabel,
-.linkflair-rage .linkflairlabel {
-    color: #FFF
-}
-
-.linkflair-rage .linkflairlabel {
-    background-color: red
-}
-
-.linkflair-blizzcon .linkflairlabel {
-    background-color: #00008B
-}
-
-.linkflair-blizzreply .linkflairlabel {
-    font-size: 11px;
-    display: inline-block;
-    max-width: 11em!important;
-    height: auto;
-    background: #333;
-    position: relative;
-    color: rgba(0, 195, 255, 1);
-    padding: 3px 6px;
-    font-weight: 700;
-    text-shadow: 1px 1px #000
-}
-
 .arrow,
 .arrow:hover {
     background-color: transparent
@@ -3361,3 +3259,5 @@ html.res-commentBoxes .comment {
 #RESShortcuts {
     color: grey
 }
+
+@import "link_flair";

--- a/link_flair.scss
+++ b/link_flair.scss
@@ -1,102 +1,82 @@
-.linkflair-modpost .linkflairlabel {
-    background-color: #add5ab;
-    font-size: 11px;
-    font-weight: 700;
-    color: #000;
-    border-color: #000;
-    border-width: 1px
-}
-
-.linkflair-blizzard .linkflairlabel,
-.linkflair-weekly .linkflairlabel {
-    background-color: #000;
-    font-size: 11px;
-    font-weight: 700;
-    border-color: #000
-}
-
-.linkflair-weekly .linkflairlabel {
-    color: #FFF;
-    border-width: 1px
-}
-
-.linkflair-blizzard .linkflairlabel {
-    color: #00b4ff;
-    border-width: 0;
-    padding: 3px
-}
-
-.linkflair-Default .linkflairlabel,
-.linkflair-awesome .linkflairlabel,
 .linkflair-blizzcon .linkflairlabel,
 .linkflair-bug .linkflairlabel,
+.linkflair-creative .linkflairlabel,
 .linkflair-esports .linkflairlabel,
 .linkflair-gameplay .linkflairlabel,
+.linkflair-news .linkflairlabel,
 .linkflair-rage .linkflairlabel,
-.linkflair-show .linkflairlabel,
-.linkflair-vod .linkflairlabel {
+.linkflair-suggestion .linkflairlabel,
+.linkflair-teaching .linkflairlabel {
     font-size: 11px;
-    font-weight: 700
+    font-weight: 700;
 }
 
-.linkflair-gameplay .linkflairlabel {
-    background-color: #900;
-    color: #FFF
-}
-
-.linkflair-vod .linkflairlabel {
-    background-color: #36F;
-    color: #FFF
+.linkflair-blizzcon .linkflairlabel {
+    background-color: #7DF;
+    color: #FFF;
 }
 
 .linkflair-bug .linkflairlabel {
     background-color: #E68A00;
-    color: #FFF
+    color: #000;
 }
 
-.linkflair-show .linkflairlabel {
-    background-color: #060;
-    color: #FFF
+.linkflair-creative .linkflairlabel {
+    background-color: #68A;
+    color: #FFF;
 }
 
 .linkflair-esports .linkflairlabel {
-    background-color: #330081;
-    color: #FFF
+    background-color: #6A3;
+    color: #FFF;
 }
 
-.linkflair-awesome .linkflairlabel {
-    background-color: #FFF;
-    color: #000
+.linkflair-gameplay .linkflairlabel {
+    background-color: #28A;
+    color: #FFF;
 }
 
-.linkflair-Default .linkflairlabel {
-    background-color: #AAA;
-    color: #000
-}
-
-.linkflair-blizzcon .linkflairlabel,
-.linkflair-rage .linkflairlabel {
-    color: #FFF
+.linkflair-news .linkflairlabel {
+    background-color: #40B;
+    color: #FFF;
 }
 
 .linkflair-rage .linkflairlabel {
-    background-color: red
+    background-color: red;
+    color: #FFF;
 }
 
-.linkflair-blizzcon .linkflairlabel {
-    background-color: #00008B
+.linkflair-suggestion .linkflairlabel {
+    background-color: #634;
+    color: #FFF;
+}
+
+.linkflair-teaching .linkflairlabel {
+    background-color: #9FF;
+    color: #000;
+}
+
+// Blizzard-related flairs
+
+.linkflair-blizzard .linkflairlabel {
+    background-color: #000;
+    border-color: #000;
+    border-width: 0;
+    color: #00b4ff;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px;
 }
 
 .linkflair-blizzreply .linkflairlabel {
-    font-size: 11px;
-    display: inline-block;
-    max-width: 11em!important;
-    height: auto;
     background: #333;
-    position: relative;
     color: rgba(0, 195, 255, 1);
-    padding: 3px 6px;
+    display: inline-block;
+    font-size: 11px;
     font-weight: 700;
-    text-shadow: 1px 1px #000
+    height: auto;
+    max-width: 11em!important;
+    padding: 3px 6px;
+    position: relative;
+    text-shadow: 1px 1px #000;
 }
-

--- a/link_flair.scss
+++ b/link_flair.scss
@@ -1,0 +1,102 @@
+.linkflair-modpost .linkflairlabel {
+    background-color: #add5ab;
+    font-size: 11px;
+    font-weight: 700;
+    color: #000;
+    border-color: #000;
+    border-width: 1px
+}
+
+.linkflair-blizzard .linkflairlabel,
+.linkflair-weekly .linkflairlabel {
+    background-color: #000;
+    font-size: 11px;
+    font-weight: 700;
+    border-color: #000
+}
+
+.linkflair-weekly .linkflairlabel {
+    color: #FFF;
+    border-width: 1px
+}
+
+.linkflair-blizzard .linkflairlabel {
+    color: #00b4ff;
+    border-width: 0;
+    padding: 3px
+}
+
+.linkflair-Default .linkflairlabel,
+.linkflair-awesome .linkflairlabel,
+.linkflair-blizzcon .linkflairlabel,
+.linkflair-bug .linkflairlabel,
+.linkflair-esports .linkflairlabel,
+.linkflair-gameplay .linkflairlabel,
+.linkflair-rage .linkflairlabel,
+.linkflair-show .linkflairlabel,
+.linkflair-vod .linkflairlabel {
+    font-size: 11px;
+    font-weight: 700
+}
+
+.linkflair-gameplay .linkflairlabel {
+    background-color: #900;
+    color: #FFF
+}
+
+.linkflair-vod .linkflairlabel {
+    background-color: #36F;
+    color: #FFF
+}
+
+.linkflair-bug .linkflairlabel {
+    background-color: #E68A00;
+    color: #FFF
+}
+
+.linkflair-show .linkflairlabel {
+    background-color: #060;
+    color: #FFF
+}
+
+.linkflair-esports .linkflairlabel {
+    background-color: #330081;
+    color: #FFF
+}
+
+.linkflair-awesome .linkflairlabel {
+    background-color: #FFF;
+    color: #000
+}
+
+.linkflair-Default .linkflairlabel {
+    background-color: #AAA;
+    color: #000
+}
+
+.linkflair-blizzcon .linkflairlabel,
+.linkflair-rage .linkflairlabel {
+    color: #FFF
+}
+
+.linkflair-rage .linkflairlabel {
+    background-color: red
+}
+
+.linkflair-blizzcon .linkflairlabel {
+    background-color: #00008B
+}
+
+.linkflair-blizzreply .linkflairlabel {
+    font-size: 11px;
+    display: inline-block;
+    max-width: 11em!important;
+    height: auto;
+    background: #333;
+    position: relative;
+    color: rgba(0, 195, 255, 1);
+    padding: 3px 6px;
+    font-weight: 700;
+    text-shadow: 1px 1px #000
+}
+


### PR DESCRIPTION
We're settling on a fixed list of seven link flair templates that users can assign to their posts:
```
1. Bugs
2. Creative
3. eSports
4. Gameplay
5. News
6. Suggestions
7. Teaching
```

This PR moves link flair labels into `link_flair.scss`. Styling for link flair Markdown elements, thumbnails, etc. remain in `custom.scss`, though my hope is that we can eventually move all custom declarations to their own files.

I've given the new flair templates styling, keeping some of the old colors. Here's what they look like:
![image](https://cloud.githubusercontent.com/assets/4412803/20693363/ee96ecee-b5ab-11e6-92da-59c88a5baffb.png)
