### PR TITLE
res: Remove RES multireddit counter

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -2462,5 +2462,6 @@ html.res-commentBoxes .comment {
 }
 
 @import "link_flair";
+@import "res";
 @import "sidebar";
 @import "spoilers";

--- a/res.scss
+++ b/res.scss
@@ -1,0 +1,3 @@
+.multi-count {
+  display: none;
+}


### PR DESCRIPTION
In release 5.2.0[1], RES added a sidebar counter for the number of
multireddits that a subreddit is a part of. It doesn't look great at
all, so we remove it.

[1] https://redditenhancementsuite.com/2016/12/05/520/