### PR TITLE
res: bring back the RES multi count

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -4,7 +4,6 @@
 @import "blizzard_flair";
 @import "blizzard_taglines";
 @import "link_flair";
-@import "res";
 @import "sidebar";
 @import "spoilers";
 

--- a/res.scss
+++ b/res.scss
@@ -1,3 +1,0 @@
-span.multi-count {
-  display: none;
-}


### PR DESCRIPTION
We can support the multi count in a "degraded" state, but leave it up to
users to decide whether they want to have the count or not. Hiding it
entirely removes that choice and could be frustrating for some.