### PR TITLE
user_flair: correct background-image position bug

### DIFF
--- a/modules/_user_flair.scss
+++ b/modules/_user_flair.scss
@@ -2,7 +2,7 @@ $flair-height: 20px;
 $flair-width: 40px;
 
 @function flair-position-width($index) {
-  @return $flair-width * $index;
+  @return $flair-width * $index * -1;
 }
 
 @function flair-position-height($index) {


### PR DESCRIPTION
We've been using background-position incorrectly all this time. It
shifts the background image relative to the imaginary background layer,
not relative to the location of the selected element.

The reason we've never had a problem with this before because browsers
will automatically repeat background images. Since we only had two
columns to switch between, the behavior was as if we have gone 40px
forward instead of backward.

With a third column introduced for hero star flairs, we would see
incorrect behavior, with the style for master flair showing the star
flair and the style for star flair showing the master flair.