### PR TITLE
Fix for grey top bar in RES night mode in Firefox

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -446,7 +446,7 @@ a.thumbnail img {
 .res-nightmode .search-page .content>.menuarea,
 .res-nightmode .search-page .searchpane,
 .res-nightmode .side .md>ol {
-  background-color: transparent
+  background-color: transparent !important
 }
 
 .res-nightmode .side #search #searchexpando {


### PR DESCRIPTION
Looks like in Firefox the CSS priority is different and the RES night mode stylesheet takes priority over this rule, so I added an `!important`.

https://www.reddit.com/r/heroesmeta/comments/il8n57/could_the_subreddit_top_bar_css_be_adjusted_for/